### PR TITLE
Typo: ecas -> esac

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -95,7 +95,7 @@ if [ -z "$BUNDLE_TYPE" ]; then
             # assume it's a zipfile
             BUNDLE_TYPE=zip
             ;;
-    ecas
+    esac
 fi
 
 if [ $BUNDLE_TYPE == 'zip' ]; then


### PR DESCRIPTION
Another small fix for a typo 

change ecas to esac