### PR TITLE
Fix the check for appspec.yml

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -104,7 +104,7 @@ if [ "$BUNDLE_TYPE" == 'zip' ]; then
         exit 1;
     fi
 else
-    if tar -tf "$ZIP_FILENAME" | grep -qv appspec.yml; then
+    if ! tar -tf "$ZIP_FILENAME" | grep -q appspec.yml; then
         echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
         exit 1;
     fi


### PR DESCRIPTION
Fixes the issue with check for `appspec.yml`

- Previously, it would return true if any file other than `appspec.yml`exists as we are using the inverse argument. 
- Now, it would return true only when `appspec.yml` is not found in the tar zip